### PR TITLE
fix: remove invalid semicolon in services/index.astro JSX map block (…

### DIFF
--- a/src/pages/services/index.astro
+++ b/src/pages/services/index.astro
@@ -73,8 +73,7 @@ const getSlug = (service) => service.slug || service.id.replace(/\.[^/.]+$/, '')
                   </span>
                 </div>
               </a>
-            );
-          })}
+          ))}
         </div>
       </section>
     )}


### PR DESCRIPTION
…Astro syntax error)

## Summary by Sourcery

Bug Fixes:
- Remove invalid semicolon and extra braces in services/index.astro JSX map block to resolve Astro syntax error.